### PR TITLE
ev3dev: document that LED use is racey when concurrent

### DIFF
--- a/ev3dev/led.go
+++ b/ev3dev/led.go
@@ -12,6 +12,11 @@ import (
 )
 
 // LED represents a handle to an ev3 LED.
+//
+// Interaction with shared physical resources is intrinsically
+// subject to race conditions without a transactional model,
+// which is not provided here. If concurrent access to LEDs is
+// needed, the user is required to establish this model.
 type LED struct {
 	color string
 	side  string


### PR DESCRIPTION
It is possible to silence the race detector for access to the err field
and serialise device writes, but this does not address the issue that
call chains are not atomic.

Making call chains transactional adds complexity that does not seem
justified (the behaviour resulting from serialised concurrent access to
flashing lights does not seem to be meaningful in most cases). So leave
the memory race behaviour visible to be seen by the race detector, but
document the raciness.

Fixes #9.